### PR TITLE
Added PR labels checks

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -139,26 +139,3 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  branch-name:
-    name: Validate branch name pattern
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check branch name pattern
-        # For the pattern see also ../release-drafter-labeler-config.yml
-        env:
-          BRANCH: ${{ github.head_ref }}
-        run: |
-          if [[ "${BRANCH}" == "develop" ]]; then
-            echo "Branch name is 'develop', skipping pattern check"
-            exit 0
-          fi
-          if [[ "${BRANCH}" == "main" ]]; then
-            echo "Branch name is 'main', skipping pattern check"
-            exit 0
-          fi
-          expected_pattern="^(feature|feat|bugfix|bug|hotfix|hot|data|norn|skip-rn)[/_-].+$"
-          if [[ ! "${BRANCH}" =~ ${expected_pattern} ]]; then
-            echo "Invalid branch name: ${BRANCH}, expected pattern: ${expected_pattern}"
-            exit 1
-          fi

--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -34,7 +34,6 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
     steps:
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -140,3 +139,26 @@ jobs:
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  branch-name:
+    name: Validate branch name pattern
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name pattern
+        # For the pattern see also ../release-drafter-labeler-config.yml
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          if [[ "${BRANCH}" == "develop" ]]; then
+            echo "Branch name is 'develop', skipping pattern check"
+            exit 0
+          fi
+          if [[ "${BRANCH}" == "main" ]]; then
+            echo "Branch name is 'main', skipping pattern check"
+            exit 0
+          fi
+          expected_pattern="^(feature|feat|bugfix|bug|hotfix|hot|data|norn|skip-rn)[/_-].+$"
+          if [[ ! "${BRANCH}" =~ ${expected_pattern} ]]; then
+            echo "Invalid branch name: ${BRANCH}, expected pattern: ${expected_pattern}"
+            exit 1
+          fi

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,78 @@
+name: PR Label Validation Reusable Workflow
+
+# Validate that the PR has exactly one of the required category labels and none of the
+# forbidden labels. This is triggered on label changes so that manually adding or removing
+# a label re-runs the validation.
+
+# NOTES:
+#  - this workflow only works for github pull_request trigger
+#  - Github labels are managed by Terraform, see https://github.com/swissgeo/infra-terraform/blob/main/github/modules/issue-labels/main.tf
+
+# Usage example:
+# on:
+#   pull_request:
+#     types:
+#       - labeled
+#       - unlabeled
+
+on:
+  workflow_call:
+    inputs:
+      required_labels:
+        description: 'JSON array of labels; exactly one must be present on the PR'
+        type: string
+        default: '["bug", "feature", "new-release", "data-integration"]'
+      forbidden_labels:
+        description: 'JSON array of labels that must not be present on the PR'
+        type: string
+        default: '["DO NOT MERGE :bomb:", "WIP :construction:"]'
+
+jobs:
+  pr-labels:
+    name: Validate PR labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required and forbidden labels
+        uses: actions/github-script@v9
+        env:
+          REQUIRED_LABELS: ${{ inputs.required_labels }}
+          FORBIDDEN_LABELS: ${{ inputs.forbidden_labels }}
+        with:
+          script: |
+            // Every PR is also an issue in GitHub's API, so the issues endpoint returns PR labels too.
+            const { data: issueLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const labels = issueLabels.map((label) => label.name);
+            core.info(`PR labels: ${JSON.stringify(labels)}`);
+
+            const forbiddenLabels = JSON.parse(process.env.FORBIDDEN_LABELS);
+            for (const label of forbiddenLabels) {
+              if (labels.includes(label)) {
+                core.setFailed(`PR has forbidden label: ${label}`);
+                return;
+              }
+            }
+
+            if (labels.includes("skip-relase-note")) {
+              core.info(`PR has skip-release-note label`);
+              return;
+            }
+
+            // Exactly one of these category labels is required (other labels are allowed alongside it)
+            const requiredLabels = JSON.parse(process.env.REQUIRED_LABELS);
+            const matched = requiredLabels.filter((label) => labels.includes(label));
+
+            if (matched.length === 0) {
+              core.setFailed(`PR must have one of the following labels: ${requiredLabels.join(", ")}`);
+              return;
+            }
+
+            if (matched.length > 1) {
+              core.setFailed(`PR must have only one of the following labels, found: ${matched.join(", ")}`);
+              return;
+            }
+
+            core.info(`PR label check passed: ${matched.join(", ")}`);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -56,7 +56,8 @@ jobs:
               }
             }
 
-            if (labels.includes("skip-relase-note")) {
+            // If the skip-release-note label is present, no further check is needed
+            if (labels.includes("skip-release-note")) {
               core.info(`PR has skip-release-note label`);
               return;
             }

--- a/workflow-templates/pr-labels.properties.json
+++ b/workflow-templates/pr-labels.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "PR Label Validation Workflow",
+    "description": "PR label validation workflow template for Swissgeo project. This template validates that a PR has exactly one required category label and no forbidden labels, re-checking whenever a label is added or removed.",
+    "iconName": "swissgeo-logo",
+    "categories": [
+        "JavaScript", "TypeScript", "Python"
+    ]
+}

--- a/workflow-templates/pr-labels.yml
+++ b/workflow-templates/pr-labels.yml
@@ -1,0 +1,11 @@
+name: on-pr-label
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  pr-labels:
+    uses: swissgeo/.github/.github/workflows/pr-labels.yml@main


### PR DESCRIPTION
Github branch nomenclature is used to automate PR labels which are then used to categorize Release Notes. Branch name otherwise are not so important and they are automatically deleted once the PR is merged. Therefore any convention enforcement do not really make sense and it would also be quite annoying because once a PR is open, you cannot change the name of the head branch, in that case you need to close the PR and reopen a new one.

However the PR labels are important and should be enforced for proper Release Note Categorization. That's why this PR now implement a supplementary github action that can be used with PR label and unlabel events. I also added a PR merge guards to prevent accidental merge of PR labeled as DO NOT MERGE or WIP.

This is a new reusable workflow which means that it needs to be added to every github repo. See https://github.com/swissgeo/infra-terraform/pull/423 for the workfow setup