### PR TITLE
GPS-835: Make the pr-auto-infra workflow less verbose in github status

### DIFF
--- a/.github/workflows/pr-auto-infra.yml
+++ b/.github/workflows/pr-auto-infra.yml
@@ -33,9 +33,7 @@ on:
 
 jobs:
   content:
-    name: Validate PR content
     uses: ./.github/workflows/pr-content.yml
 
   labels:
-    name: Set and validate PR labels
     uses: ./.github/workflows/pr-labels.yml


### PR DESCRIPTION
The github status check was

```
on-pr / infra / Validate PR content / Validate commit messages
```

Which is quite verbose and repetitive. Now it is

```
on-pr / infra / content / Validate commit messages
```