### PR TITLE
GPS-835: Recover pr-auto-infra.yml reusable workflow

### DIFF
--- a/.github/workflows/pr-auto-infra.yml
+++ b/.github/workflows/pr-auto-infra.yml
@@ -1,0 +1,39 @@
+name: PR Labels and Content Reusable Workflow for infra repository
+
+# Validate the PR content: title pattern, description not empty and commit message patterns.
+#
+# Add a Label to the PR based on HEAD branch name. These labels are then used to categorize
+# the release notes.
+#
+# Check the labels against labels for release note categorization and merge guards
+#
+# NOTE: Even if we don't use release notes on infra repository it is good to keep the same PR
+# quality as for release note to enforce a good code documentation via PR.
+
+# NOTE: this workflow only works for github pull_request trigger
+
+# Usage example:
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - reopened
+#       - synchronize
+#       - edited
+#       - labeled
+#       - unlabeled
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+on:
+  workflow_call:
+
+jobs:
+  content:
+    uses: ./.github/workflows/pr-content.yml
+
+  labels:
+    uses: ./.github/workflows/pr-labels.yml


### PR DESCRIPTION
The workflow has been overwritten by https://github.com/swissgeo/infra-terraform/pull/446 which create the main workflow in every infra repo (including this repo). The terraform managed main workflow had the same name and overwrite the reusable workflow which breaks everything.

This commit reverts both terraform commit that cause the issue, see below. And now terraform use another name for the main file; pr-auto-infra-main.yml to avoid any collusion.

Revert "Added/Modified github workflows pr-auto-infra.yml #skip-tagging-and-release" This reverts commit 1347664061c317629b21847dacae38f97714d0ee.

Revert "Added/Modified github workflows pr-auto-infra.yml #skip-tagging-and-release" This reverts commit 1f9fdf2f3f95873e2a71881ffa9b85efc0558baf.