### PR TITLE
CHORE: update release drafter to avoid deprecation warnings:

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: PR Auto Labeler
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter-labeler-config.yml
           disable-autolabeler: false


### PR DESCRIPTION
This should remove the following warnings:

Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: release-drafter/release-drafter@v6.

It could also potentially remove those warnings:

"pull_request_target.synchronize/edited/reopened/opened" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)