### PR TITLE
CHORE: Fixing other release-drafter warnings due to upgrade

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -46,14 +46,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: PR Auto Labeler
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter/autolabeler@v7
         with:
           config-name: release-drafter-labeler-config.yml
-          disable-autolabeler: false
-          disable-releaser: true
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   labels-check:
     name: Validate PR labels


### PR DESCRIPTION
Note: those warnings have been already fixed on geoadmin/.github repo.