### PR TITLE
GPS-835: Use `chore: ` lower case in commit and PR titles

### DIFF
--- a/.github/workflows/pr-content.yml
+++ b/.github/workflows/pr-content.yml
@@ -1,7 +1,7 @@
 name: PR Content Validation Reusable Workflow
 
 # Validate the PR content as follow:
-# - PR title matches the pattern ^(((<jira_project_keys>)-\d+)+|CHORE): .+$ and does not contain "wip"
+# - PR title matches the pattern ^(((<jira_project_keys>)-\d+)+|chore): .+$ and does not contain "wip"
 # - PR description is not empty
 # - All commit messages match the same pattern as the PR title
 
@@ -42,14 +42,14 @@ jobs:
             //   ✅ GPS-123: Add feature X
             //   ❌ GPS-123 Add feature X
             //   ❌ GPS-123:
-            //   ✅ CHORE: Update library Y
-            //   ❌ chore: Update library Y
+            //   ✅ chore: Update library Y
+            //   ❌ CHORE: Update library Y
             //   ❌ no-issue: Update library Y
             //   ❌ GPS-123: Add feature X (wip)
 
             const title = context.payload.pull_request.title;
             const jiraProjectKeys = JSON.parse(process.env.JIRA_PROJECT_KEYS);
-            const titlePattern = new RegExp(`^(((${jiraProjectKeys.join("|")})-\\d+)+|CHORE): .+$`);
+            const titlePattern = new RegExp(`^(((${jiraProjectKeys.join("|")})-\\d+)+|chore(\\(deps\\))?): .+$`);
 
             if (!titlePattern.test(title)) {
               core.setFailed(`PR title "${title}" does not match the required pattern: ${titlePattern}`);
@@ -99,7 +99,7 @@ jobs:
             }
 
             const jiraProjectKeys = JSON.parse(process.env.JIRA_PROJECT_KEYS);
-            const titlePattern = new RegExp(`^(((${jiraProjectKeys.join("|")})-\\d+)+|CHORE): .+$`);
+            const titlePattern = new RegExp(`^(((${jiraProjectKeys.join("|")})-\\d+)+|chore(\\(deps\\))?): .+$`);
 
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -9,14 +9,8 @@
     ":prConcurrentLimit10"
   ],
   "minimumReleaseAge": "2d",
-  // config:recommended enables semantic commits in "auto" mode, which would
-  // produce "chore(deps): ..." in repos that already use semantic commits and
-  // would override commitMessagePrefix. Disable it so the prefix below applies
-  // consistently in every repo extending this preset.
+  // config:recommended enables semantic commits in "auto" mode, which
+  // produce "chore(deps): ..." in repos that already use semantic commits
   // https://docs.renovatebot.com/configuration-options/#semanticcommits
-  "semanticCommits": "disabled",
-  // Applies to both the commit message and the PR title (the PR title is
-  // derived from the commit message), matching the "CHORE: ..." convention.
-  // https://docs.renovatebot.com/configuration-options/#commitmessageprefix
-  "commitMessagePrefix": "CHORE:"
+  "semanticCommits": "enabled"
 }


### PR DESCRIPTION
Lots of open source projects follows https://www.conventionalcommits.org/en/v1.0.0/#specification and tend to use `chore` in lowercase instead of upper. Also Renovate by default uses `chore(deps): ` as commit title prefix.

So try to align a bit more to this convention.

NOTE: `fix` and `feat` type from the convention would not add any plus value in our workflow, because we use PR labels for release notes categorization (using Github auto generator). It would also increase the length of the title as we MUST have the jira ticket number in the title in order to have the jira automatic github linkage to work.