### PR TITLE
GPS-835: Fixed renovate auto generated PR and added support for conventional branch

### DIFF
--- a/.github/release-drafter-labeler-config.yml
+++ b/.github/release-drafter-labeler-config.yml
@@ -5,25 +5,26 @@ autolabeler:
       - '/^develop-/'
   - label: 'data-integration'
     branch:
-      - '/^data[-_]/'
+      - '/^data[-_/]/'
   - label: 'bug'
     branch:
-      - '/^bug[-_]/'
-      - '/^bugfix[-_]/'
-      - '/^fix[-_]/'
+      - '/^bug[-_/]/'
+      - '/^bugfix[-_/]/'
+      - '/^fix[-_/]/'
   - label: 'hotfix'
     branch:
-      - '/^hotfix[-_]/'
-      - '/^hot[-_]/'
+      - '/^hotfix[-_/]/'
+      - '/^hot[-_/]/'
   - label: 'feature'
     branch:
-      - '/^feature[-_]/'
-      - '/^feat[-_]/'
+      - '/^feature[-_/]/'
+      - '/^feat[-_/]/'
   - label: 'skip-release-note'
     branch:
       - '/update_README\.md/'
       - '/\bnorn\b/'
       - '/\bskip[-_]?rn\b/'
+      - '/^chore[-_/]/'
   - label: 'dependencies'
     branch:
       - '/^renovate[-_/]/'

--- a/.github/release-drafter-labeler-config.yml
+++ b/.github/release-drafter-labeler-config.yml
@@ -24,4 +24,9 @@ autolabeler:
       - '/update_README\.md/'
       - '/\bnorn\b/'
       - '/\bskip[-_]?rn\b/'
+  - label: 'dependencies'
+    branch:
+      - '/^renovate[-_/]/'
+      - '/^dependabot[-_/]/'
+      - '/^dep[-_/]/'
 template: '# Labeler'


### PR DESCRIPTION
Renovate generate and open PR using `renovate/` branch prefix (see https://github.com/swissgeo/web-portal/actions/runs/31135413670). This prefix was not known to our auto labeler and therefore PR did not had the proper label and the workflow failed.

I also added other meaningful prefix for dependencies.

Also added support for https://conventionalbranch.org/